### PR TITLE
add assume role code

### DIFF
--- a/src/main/java/moonset/metastore/sync/MetastoreClientFactory.java
+++ b/src/main/java/moonset/metastore/sync/MetastoreClientFactory.java
@@ -88,4 +88,27 @@ public class MetastoreClientFactory {
             throw new MetastoreException("can't new a metastoreclient.", e);
         }
     }
+
+    /**
+     * Get a datacatlog client across account. 
+     *
+     * @param region the glue service region.
+     * @param assumeRole the role to assume in the target account. 
+     * @return an IMetaStoreClient instance for AWS DataCatalog not on EMR.
+     * @throws MetastoreException if failed to get an IMetaStoreClient istance.
+     */
+    public IMetaStoreClient getDataCatalogClient(final String region, final String assumeRole)
+            throws MetastoreException {
+        try {
+            HiveConf conf = new HiveConf();
+            conf.set(AWSGlueClientFactory.AWS_REGION, region);
+            conf.set(AWSGlueClientFactory.AWS_CATALOG_CREDENTIALS_PROVIDER_FACTORY_CLASS,
+                    "moonset.metastore.sync.RoleBasedAWSCredentialsProviderFactory");
+            conf.set(RoleBasedAWSCredentialsProviderFactory.ASSUME_ROLE, assumeRole);
+
+            return new NoFileSystemOpsAWSCatalogMetastoreClient(conf);
+        } catch (MetaException e) {
+            throw new MetastoreException("can't new a metastoreclient.", e);
+        }
+    }
 }

--- a/src/main/java/moonset/metastore/sync/RoleBasedAWSCredentialsProviderFactory.java
+++ b/src/main/java/moonset/metastore/sync/RoleBasedAWSCredentialsProviderFactory.java
@@ -1,0 +1,35 @@
+package moonset.metastore.sync;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.glue.catalog.metastore.AWSCredentialsProviderFactory;
+
+import java.util.UUID;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.hive.conf.HiveConf;
+
+public class RoleBasedAWSCredentialsProviderFactory implements AWSCredentialsProviderFactory {
+
+    private static final Log log = 
+        LogFactory.getLog(RoleBasedAWSCredentialsProviderFactory.class);
+
+    public static final String ASSUME_ROLE = "moonset.metastore.sync.assume.role";
+
+    private static final String ROLE_SESSION_NAME_PREFIX = "MoonsetMetastoreSync";
+
+    private static final int ROLE_SESSION_TIMEOUT_SECONDS = 3600; // Should be between 900 to 3600
+
+
+    @Override
+    public AWSCredentialsProvider buildAWSCredentialsProvider(HiveConf hiveConf) {
+        String assumeRole = hiveConf.get(ASSUME_ROLE);
+        log.info("The assume role is " + assumeRole);
+        return new STSAssumeRoleSessionCredentialsProvider.Builder(
+                assumeRole, ROLE_SESSION_NAME_PREFIX +
+                UUID.randomUUID().getMostSignificantBits()) // Using UUID to make the session name unique among multiple sessions
+            .withRoleSessionDurationSeconds(ROLE_SESSION_TIMEOUT_SECONDS)
+            .build();
+    }
+}


### PR DESCRIPTION
Allow to access glue tables across account.

An additional requirement is EMR should have permission to the s3 paths corresponding to the glue table. One easy way is to modify the s3 bucket policy. Here is an example.

```
{
    "Version": "2012-10-17",
    "Id": "Policy1588933754831",
    "Statement": [
        {
            "Sid": "MoonsetS3ResourceSharing",
            "Effect": "Allow",
            "Principal": {
                "AWS": [
                    "542947461172"
                ]
            },
            "Action": [
                "s3:Get*",
                "s3:List*"
            ],
            "Resource": "arn:aws:s3:::wzh-moonset-2/tmp/*"
        },
        {
            "Sid": "MoonsetS3BucketSharing",
            "Effect": "Allow",
            "Principal": {
                "AWS": [
                    "542947461172"
                ]
            },
            "Action": "s3:ListBucket",
            "Resource": "arn:aws:s3:::wzh-moonset-2",
            "Condition": {
                "StringLike": {
                    "s3:prefix": "tmp/*"
                }
            }
        }
    ]
}
```
